### PR TITLE
Add force_generic to dict_to_object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased => [0.4.5]
 ## Added
+- Dev Objects : add maldefined method
+- Typings : add Mass typing
+- Add force_generic argument to dict_to_object to avoid recursion when generic computation is needed
 - Dict typing serilization/deserialization
 - All typings serialization
 - python_typing is set in all jsonschema

--- a/dessia_common/core.py
+++ b/dessia_common/core.py
@@ -3,6 +3,7 @@
 """
 
 """
+import builtins
 import sys
 import warnings
 import math
@@ -288,7 +289,8 @@ class DessiaObject:
         return serialized_dict
 
     @classmethod
-    def dict_to_object(cls, dict_: JsonSerializable) -> 'DessiaObject':
+    def dict_to_object(cls, dict_: JsonSerializable,
+                       force_generic: bool = False) -> 'DessiaObject':
         """
         Generic dict_to_object method
         """
@@ -298,10 +300,11 @@ class DessiaObject:
             return cls.DictToObject(dict_)
 
         if cls is not DessiaObject:
-            obj = dict_to_object(dict_, cls)
+            obj = dict_to_object(dict_=dict_, class_=cls,
+                                 force_generic=force_generic)
             return obj
         elif 'object_class' in dict_:
-            obj = dict_to_object(dict_)
+            obj = dict_to_object(dict_=dict_, force_generic=force_generic)
             return obj
         else:
             # Using default
@@ -489,8 +492,6 @@ class DessiaObject:
         else:
             dict_ = json.loads(filepath.read().decode('utf-8'))
         return cls.dict_to_object(dict_)
-
-
 
     def is_valid(self):
         return True
@@ -949,17 +950,18 @@ def get_python_class_from_class_name(full_class_name):
     return class_
 
 
-def dict_to_object(dict_, class_=None):
+def dict_to_object(dict_, class_=None, force_generic: bool = False):
     working_dict = dict_.copy()
     if class_ is None and 'object_class' in working_dict:
         class_ = get_python_class_from_class_name(working_dict['object_class'])
 
-    if class_ is not None:
-        if hasattr(class_, 'dict_to_object') \
-                and (class_.dict_to_object.__func__
-                     is not DessiaObject.dict_to_object.__func__):
+    if class_ is not None and issubclass(class_, DessiaObject):
+        different_methods = (class_.dict_to_object.__func__
+                             is not DessiaObject.dict_to_object.__func__)
+        if different_methods and not force_generic:
             obj = class_.dict_to_object(dict_)
             return obj
+
         if class_._init_variables is None:
             class_argspec = inspect.getfullargspec(class_)
             init_dict = {k: v for k, v in working_dict.items()

--- a/dessia_common/forms.py
+++ b/dessia_common/forms.py
@@ -340,6 +340,19 @@ class StandaloneObject(DessiaObject):
         return [primitives_group, scatter_plot,
                 parallel_plot, multi_plot, graph2d]
 
+    def maldefined_method(self, arg0, arg1=1, arg2: int = 10, arg3 = 3):
+        """
+        Defining a docstring for testing parsing purpose
+        """
+        nok_string = "This is a bad coding behavior"
+        ok_string = "This could be OK as temporary attr"
+        self.maldefined_attr = nok_string
+        self._ok_attribute = ok_string
+
+        computation = nok_string + 'or' + ok_string
+
+        return computation
+
 
 DEF_SO = StandaloneObject.generate(1)
 

--- a/dessia_common/typings.py
+++ b/dessia_common/typings.py
@@ -24,3 +24,8 @@ class Measure(float):
 
 class Distance(Measure):
     units = 'm'
+
+
+class Mass(Measure):
+    units = 'kg'
+

--- a/dessia_common/vectored_objects.py
+++ b/dessia_common/vectored_objects.py
@@ -154,7 +154,7 @@ class Catalog(DessiaObject):
     _ordered_attributes = ['name', 'pareto_settings', 'objectives']
     _non_editable_attributes = ['array', 'variables', 'choice_variables',
                                 'generated_best_objectives']
-    _export_formats = ['csv']
+    # _export_formats = ['csv']
     _allowed_methods = ['find_best_objective']
     _whitelist_attributes = ['variables']
 

--- a/dessia_common/workflow.py
+++ b/dessia_common/workflow.py
@@ -62,7 +62,7 @@ class TypedVariable(Variable):
 
     def to_dict(self):
         dict_ = DessiaObject.base_dict(self)
-        dict_.update({'type': serialize_typing(self.type_),
+        dict_.update({'type_': serialize_typing(self.type_),
                       'memorize': self.memorize,
                       'has_default_value': self.has_default_value})
         return dict_
@@ -93,7 +93,7 @@ class TypedVariableWithDefaultValue(TypedVariable):
 
     def to_dict(self):
         dict_ = DessiaObject.base_dict(self)
-        dict_.update({'type': serialize_typing(self.type_),
+        dict_.update({'type_': serialize_typing(self.type_),
                       'default_value': serialize(self.default_value),
                       'memorize': self.memorize,
                       'has_default_value': self.has_default_value})
@@ -327,7 +327,7 @@ class ClassMethod(Block):
 
         annotations = get_type_hints(method)
         type_ = type_from_annotation(annotations['return'],
-                                        method.__module__)
+                                     method.__module__)
         output_name = 'method result of {}'.format(self.method_name)
         outputs = [TypedVariable(type_=type_, name=output_name)]
         Block.__init__(self, inputs, outputs, name=name)


### PR DESCRIPTION
* **What kind of changes does this PR introduce?** 
- [x] Bug fix
- [ ] new features
- [ ] performance 
- [ ] docs update

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- [ ] Yes:
- [x] No


* **Other information**:

When we need, for some reasons, to overwrite dict_to_object method but still use DessiaObject's generic computation of it, we end up in a infinite loop recursion.

For example, PlotDataObject juste need to remove object_class in object_dict and reset it in dict_to_object, while still using DessiaObject's dict_to_object.

To tackle this a force_generic argument has been added to prevent DessiaObject's dict_to_object to still dig inside subclass's dict_to_object that calls again DessiaObject's. instead it goes straight to generic arguments computations and class instantiation 
