### PR TITLE
fix: kwargs were not used in dict to object

### DIFF
--- a/dessia_common/core.py
+++ b/dessia_common/core.py
@@ -618,6 +618,7 @@ class DessiaObject:
         decoded_json = json.loads(json_dict)
         deserialized_object = self.dict_to_object(decoded_json)
         if not deserialized_object._data_eq(self):
+            print('data diff: ', self._data_diff(deserialized_object))
             raise dessia_common.errors.DeserializationError('Object is not equal to itself'
                                                             ' after serialization/deserialization')
         copied_object = self.copy()

--- a/dessia_common/utils/serialization.py
+++ b/dessia_common/utils/serialization.py
@@ -231,8 +231,9 @@ def dict_to_object(dict_, class_=None, force_generic: bool = False,
             return obj
 
         class_argspec = inspect.getfullargspec(class_)
+        class_args = class_argspec.args+class_argspec.kwonlyargs
         init_dict = {k: v for k, v in dict_.items()
-                     if k in class_argspec.args}
+                     if k in class_args}
         # TOCHECK Class method to generate init_dict ??
     else:
         init_dict = dict_
@@ -252,6 +253,7 @@ def dict_to_object(dict_, class_=None, force_generic: bool = False,
                                           global_dict=global_dict,
                                           pointers_memo=pointers_memo,
                                           path=key_path)  # , enforce_pointers=False)
+
 
     if class_ is not None:
         obj = class_(**subobjects)

--- a/dessia_common/utils/serialization.py
+++ b/dessia_common/utils/serialization.py
@@ -231,9 +231,8 @@ def dict_to_object(dict_, class_=None, force_generic: bool = False,
             return obj
 
         class_argspec = inspect.getfullargspec(class_)
-        class_args = class_argspec.args+class_argspec.kwonlyargs
         init_dict = {k: v for k, v in dict_.items()
-                     if k in class_args}
+                     if k in class_argspec.args+class_argspec.kwonlyargs}
         # TOCHECK Class method to generate init_dict ??
     else:
         init_dict = dict_


### PR DESCRIPTION
Using kwargs in dict to object. They were not used and default values were injected