### PR TITLE
perf: use a much faster method to get desrialization order

### DIFF
--- a/dessia_common/graph.py
+++ b/dessia_common/graph.py
@@ -33,40 +33,10 @@ def cut_tree_final_branches(graph: nx.DiGraph):
 
 
 def explore_tree_from_leaves(graph: nx.DiGraph):
-    exploration_order = []
-    explored = {n: False for n in graph.nodes}
-    number_nodes = graph.number_of_nodes()
-    successors = {}
+    if not nx.is_directed_acyclic_graph(graph):
+        raise NotImplementedError('Cycles in jsonpointers not handled')
 
-    # ns = 0
-    while number_nodes:
-        found_node = False
-        # Finding a starting node
-        for node in graph.nodes:
-            if not explored[node]:
-                neighbors_explored = True
-                if node in successors:
-                    node_successors = successors[node]
-                else:
-                    node_successors = list(graph.successors(node))
-                    successors[node] = node_successors
-                    # ns += 1
-
-                for out_node in node_successors:
-                    if not explored[out_node]:
-                        neighbors_explored = False
-                        break
-
-                if neighbors_explored:
-                    # Mark explored
-                    explored[node] = True
-                    exploration_order.append(node)
-                    number_nodes -= 1
-                    found_node = True
-                    break
-        if not found_node:
-            raise ValueError('Can not find a node')
-    return exploration_order
+    return list(nx.topological_sort(graph))
 
 
 def extract_region(networkx_graph: nx.Graph, nodes, distance: int = 5):


### PR DESCRIPTION
* **What kind of changes does this PR introduce?** 
- [ ] Bug fix
- [ ] new features
- [x] performance 
- [ ] docs update

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- [ ] Yes:
- [x] No


* **Other information**:
match faster object deserialization with topological sort algorithm.
on a use case for Mack, explore_tree_from_leaves went from over 30 minutes (needed to be stoped as it was not practical, we cant wait that much to deserialize an object) to a couple seconds.
