### PR TITLE
Fix: PhysicalObject.to_stl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## 0.16.2
+
+### Fix
+
+- PhysicalObject : to_stl
+
 ## 0.16.1
 
 ### Fix

--- a/dessia_common/core.py
+++ b/dessia_common/core.py
@@ -708,7 +708,7 @@ class PhysicalObject(DessiaObject):
         if not filepath.endswith('.stl'):
             filepath += '.stl'
 
-        with open(filepath, 'wb', encoding='utf-8') as file:
+        with open(filepath, 'wb') as file:
             self.to_stl_stream(stream=file)
 
     def babylonjs(self, use_cdn=True, debug=False, **kwargs):


### PR DESCRIPTION
* **What kind of changes does this PR introduce?** 
- [x] Bug fix
- [ ] new features
- [ ] performance 
- [ ] docs update

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- [ ] Yes:
- [x] No


* **Other information**:

There was an issue in the `to_stl` method, introduced in dessia_common 0.16.0
```
Traceback (most recent call last):
  File "/home/gibertini/PycharmProjects/Dessia/venv/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3508, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-5-b76d18794df3>", line 1, in <module>
    mesh5.to_stl("a")
  File "/home/gibertini/PycharmProjects/Dessia/dessia_common/dessia_common/core.py", line 711, in to_stl
    with open(filepath, 'wb', encoding='utf-8') as file:
ValueError: binary mode doesn't take an encoding argument
```
